### PR TITLE
Add background synchronization support, ignored GoogleFit support, fix ios build

### DIFF
--- a/health/api/health.klib.api
+++ b/health/api/health.klib.api
@@ -49,7 +49,7 @@ abstract interface com.viktormykhailiv.kmp.health/HealthManager { // com.viktorm
     abstract suspend fun isRevokeAuthorizationSupported(): kotlin/Result<kotlin/Boolean> // com.viktormykhailiv.kmp.health/HealthManager.isRevokeAuthorizationSupported|isRevokeAuthorizationSupported(){}[0]
     abstract suspend fun readData(kotlin.time/Instant, kotlin.time/Instant, com.viktormykhailiv.kmp.health/HealthDataType): kotlin/Result<kotlin.collections/List<com.viktormykhailiv.kmp.health/HealthRecord>> // com.viktormykhailiv.kmp.health/HealthManager.readData|readData(kotlin.time.Instant;kotlin.time.Instant;com.viktormykhailiv.kmp.health.HealthDataType){}[0]
     abstract suspend fun requestAuthorization(kotlin.collections/List<com.viktormykhailiv.kmp.health/HealthDataType>, kotlin.collections/List<com.viktormykhailiv.kmp.health/HealthDataType>, kotlin/Boolean = ...): kotlin/Result<kotlin/Boolean> // com.viktormykhailiv.kmp.health/HealthManager.requestAuthorization|requestAuthorization(kotlin.collections.List<com.viktormykhailiv.kmp.health.HealthDataType>;kotlin.collections.List<com.viktormykhailiv.kmp.health.HealthDataType>;kotlin.Boolean){}[0]
-    abstract suspend fun requestReadHealthDataInBackground(): kotlin/Result<kotlin/Boolean> // com.viktormykhailiv.kmp.health/HealthManager.requestReadHealthDataInBackground|requestReadHealthDataInBackground(){}[0]
+    abstract suspend fun requestReadHealthDataInBackgroundPermission(): kotlin/Result<kotlin/Boolean> // com.viktormykhailiv.kmp.health/HealthManager.requestReadHealthDataInBackgroundPermission|requestReadHealthDataInBackgroundPermission(){}[0]
     abstract suspend fun revokeAuthorization(): kotlin/Result<kotlin/Unit> // com.viktormykhailiv.kmp.health/HealthManager.revokeAuthorization|revokeAuthorization(){}[0]
     abstract suspend fun writeData(kotlin.collections/List<com.viktormykhailiv.kmp.health/HealthRecord>): kotlin/Result<kotlin/Unit> // com.viktormykhailiv.kmp.health/HealthManager.writeData|writeData(kotlin.collections.List<com.viktormykhailiv.kmp.health.HealthRecord>){}[0]
 }
@@ -2362,6 +2362,15 @@ final class com.viktormykhailiv.kmp.health/HealthManagerFactory { // com.viktorm
     constructor <init>() // com.viktormykhailiv.kmp.health/HealthManagerFactory.<init>|<init>(){}[0]
 
     final fun createManager(): com.viktormykhailiv.kmp.health/HealthManager // com.viktormykhailiv.kmp.health/HealthManagerFactory.createManager|createManager(){}[0]
+    final fun createManager(com.viktormykhailiv.kmp.health/HealthManagerFactoryOptions = ...): com.viktormykhailiv.kmp.health/HealthManager // com.viktormykhailiv.kmp.health/HealthManagerFactory.createManager|createManager(com.viktormykhailiv.kmp.health.HealthManagerFactoryOptions){}[0]
+}
+
+final class com.viktormykhailiv.kmp.health/HealthManagerFactoryOptions { // com.viktormykhailiv.kmp.health/HealthManagerFactoryOptions|null[0]
+    constructor <init>() // com.viktormykhailiv.kmp.health/HealthManagerFactoryOptions.<init>|<init>(){}[0]
+
+    final object Companion { // com.viktormykhailiv.kmp.health/HealthManagerFactoryOptions.Companion|null[0]
+        final fun default(): com.viktormykhailiv.kmp.health/HealthManagerFactoryOptions // com.viktormykhailiv.kmp.health/HealthManagerFactoryOptions.Companion.default|default(){}[0]
+    }
 }
 
 final class com.viktormykhailiv.kmp.health/SwiftHealthManager { // com.viktormykhailiv.kmp.health/SwiftHealthManager|null[0]

--- a/health/api/health.klib.api
+++ b/health/api/health.klib.api
@@ -2360,6 +2360,9 @@ final class com.viktormykhailiv.kmp.health/HealthManagerFactory { // com.viktorm
     constructor <init>() // com.viktormykhailiv.kmp.health/HealthManagerFactory.<init>|<init>(){}[0]
 
     final fun createManager(): com.viktormykhailiv.kmp.health/HealthManager // com.viktormykhailiv.kmp.health/HealthManagerFactory.createManager|createManager(){}[0]
+    final fun createManager(com.viktormykhailiv.kmp.health/HealthManagerFactory.Options): com.viktormykhailiv.kmp.health/HealthManager // com.viktormykhailiv.kmp.health/HealthManagerFactory.createManager|createManager(com.viktormykhailiv.kmp.health.HealthManagerFactory.Options){}[0]
+
+    final object Options // com.viktormykhailiv.kmp.health/HealthManagerFactory.Options|null[0]
 }
 
 final class com.viktormykhailiv.kmp.health/SwiftHealthManager { // com.viktormykhailiv.kmp.health/SwiftHealthManager|null[0]

--- a/health/api/health.klib.api
+++ b/health/api/health.klib.api
@@ -44,10 +44,12 @@ abstract interface com.viktormykhailiv.kmp.health/HealthManager { // com.viktorm
     abstract fun isAvailable(): kotlin/Result<kotlin/Boolean> // com.viktormykhailiv.kmp.health/HealthManager.isAvailable|isAvailable(){}[0]
     abstract suspend fun aggregate(kotlin.time/Instant, kotlin.time/Instant, com.viktormykhailiv.kmp.health/HealthDataType): kotlin/Result<com.viktormykhailiv.kmp.health/HealthAggregatedRecord> // com.viktormykhailiv.kmp.health/HealthManager.aggregate|aggregate(kotlin.time.Instant;kotlin.time.Instant;com.viktormykhailiv.kmp.health.HealthDataType){}[0]
     abstract suspend fun getRegionalPreferences(): kotlin/Result<com.viktormykhailiv.kmp.health.region/RegionalPreferences> // com.viktormykhailiv.kmp.health/HealthManager.getRegionalPreferences|getRegionalPreferences(){}[0]
+    abstract suspend fun hasReadHealthDataInBackgroundPermission(): kotlin/Result<kotlin/Boolean> // com.viktormykhailiv.kmp.health/HealthManager.hasReadHealthDataInBackgroundPermission|hasReadHealthDataInBackgroundPermission(){}[0]
     abstract suspend fun isAuthorized(kotlin.collections/List<com.viktormykhailiv.kmp.health/HealthDataType>, kotlin.collections/List<com.viktormykhailiv.kmp.health/HealthDataType>): kotlin/Result<kotlin/Boolean> // com.viktormykhailiv.kmp.health/HealthManager.isAuthorized|isAuthorized(kotlin.collections.List<com.viktormykhailiv.kmp.health.HealthDataType>;kotlin.collections.List<com.viktormykhailiv.kmp.health.HealthDataType>){}[0]
     abstract suspend fun isRevokeAuthorizationSupported(): kotlin/Result<kotlin/Boolean> // com.viktormykhailiv.kmp.health/HealthManager.isRevokeAuthorizationSupported|isRevokeAuthorizationSupported(){}[0]
     abstract suspend fun readData(kotlin.time/Instant, kotlin.time/Instant, com.viktormykhailiv.kmp.health/HealthDataType): kotlin/Result<kotlin.collections/List<com.viktormykhailiv.kmp.health/HealthRecord>> // com.viktormykhailiv.kmp.health/HealthManager.readData|readData(kotlin.time.Instant;kotlin.time.Instant;com.viktormykhailiv.kmp.health.HealthDataType){}[0]
-    abstract suspend fun requestAuthorization(kotlin.collections/List<com.viktormykhailiv.kmp.health/HealthDataType>, kotlin.collections/List<com.viktormykhailiv.kmp.health/HealthDataType>): kotlin/Result<kotlin/Boolean> // com.viktormykhailiv.kmp.health/HealthManager.requestAuthorization|requestAuthorization(kotlin.collections.List<com.viktormykhailiv.kmp.health.HealthDataType>;kotlin.collections.List<com.viktormykhailiv.kmp.health.HealthDataType>){}[0]
+    abstract suspend fun requestAuthorization(kotlin.collections/List<com.viktormykhailiv.kmp.health/HealthDataType>, kotlin.collections/List<com.viktormykhailiv.kmp.health/HealthDataType>, kotlin/Boolean = ...): kotlin/Result<kotlin/Boolean> // com.viktormykhailiv.kmp.health/HealthManager.requestAuthorization|requestAuthorization(kotlin.collections.List<com.viktormykhailiv.kmp.health.HealthDataType>;kotlin.collections.List<com.viktormykhailiv.kmp.health.HealthDataType>;kotlin.Boolean){}[0]
+    abstract suspend fun requestReadHealthDataInBackground(): kotlin/Result<kotlin/Boolean> // com.viktormykhailiv.kmp.health/HealthManager.requestReadHealthDataInBackground|requestReadHealthDataInBackground(){}[0]
     abstract suspend fun revokeAuthorization(): kotlin/Result<kotlin/Unit> // com.viktormykhailiv.kmp.health/HealthManager.revokeAuthorization|revokeAuthorization(){}[0]
     abstract suspend fun writeData(kotlin.collections/List<com.viktormykhailiv.kmp.health/HealthRecord>): kotlin/Result<kotlin/Unit> // com.viktormykhailiv.kmp.health/HealthManager.writeData|writeData(kotlin.collections.List<com.viktormykhailiv.kmp.health.HealthRecord>){}[0]
 }
@@ -2360,9 +2362,6 @@ final class com.viktormykhailiv.kmp.health/HealthManagerFactory { // com.viktorm
     constructor <init>() // com.viktormykhailiv.kmp.health/HealthManagerFactory.<init>|<init>(){}[0]
 
     final fun createManager(): com.viktormykhailiv.kmp.health/HealthManager // com.viktormykhailiv.kmp.health/HealthManagerFactory.createManager|createManager(){}[0]
-    final fun createManager(com.viktormykhailiv.kmp.health/HealthManagerFactory.Options): com.viktormykhailiv.kmp.health/HealthManager // com.viktormykhailiv.kmp.health/HealthManagerFactory.createManager|createManager(com.viktormykhailiv.kmp.health.HealthManagerFactory.Options){}[0]
-
-    final object Options // com.viktormykhailiv.kmp.health/HealthManagerFactory.Options|null[0]
 }
 
 final class com.viktormykhailiv.kmp.health/SwiftHealthManager { // com.viktormykhailiv.kmp.health/SwiftHealthManager|null[0]

--- a/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/HealthConnectManager.kt
+++ b/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/HealthConnectManager.kt
@@ -1,6 +1,9 @@
 package com.viktormykhailiv.kmp.health
 
 import android.content.Context
+import android.health.connect.HealthPermissions
+import android.os.Build
+import android.os.ext.SdkExtensions
 import androidx.core.text.util.LocalePreferences
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.request.AggregateRequest
@@ -40,16 +43,32 @@ class HealthConnectManager(
     override suspend fun requestAuthorization(
         readTypes: List<HealthDataType>,
         writeTypes: List<HealthDataType>,
+        requestReadHealthDataInBackground: Boolean
     ): Result<Boolean> =
         isAuthorized(readTypes = readTypes, writeTypes = writeTypes)
+            .flatMap { isAuthorized ->
+                if (isAuthorized && requestReadHealthDataInBackground) {
+                    hasReadHealthDataInBackgroundPermission()
+                } else {
+                    Result.success(isAuthorized)
+                }
+            }
             .mapCatching { isAuthorized ->
                 if (isAuthorized) return@mapCatching true
 
+                val otherPermission = if (requestReadHealthDataInBackground) {
+                    setOf(
+                        getReadHealthDataInBackgroundKey()
+                    )
+                } else {
+                    emptySet()
+                }
                 try {
                     HealthConnectPermissionActivity.request(
                         context,
                         readPermissions = readTypes.readPermissions,
                         writePermissions = writeTypes.writePermissions,
+                        otherPermission = otherPermission
                     ).getOrThrow()
                 } catch (_: CancellationException) {
                     false
@@ -62,6 +81,32 @@ class HealthConnectManager(
 
     override suspend fun revokeAuthorization(): Result<Unit> = runCatching {
         healthConnectClient.permissionController.revokeAllPermissions()
+    }
+
+    override suspend fun hasReadHealthDataInBackgroundPermission(): Result<Boolean> = runCatching {
+        val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
+        val key = getReadHealthDataInBackgroundKey()
+        grantedPermissions.contains(key)
+    }
+
+    override suspend fun requestReadHealthDataInBackground(): Result<Boolean> {
+        return hasReadHealthDataInBackgroundPermission()
+            .mapCatching { hasBackgroundPermission ->
+                if (hasBackgroundPermission) return@mapCatching true
+                try {
+                    val key = getReadHealthDataInBackgroundKey()
+                    HealthConnectPermissionActivity.request(
+                        context,
+                        readPermissions = emptySet(),
+                        writePermissions = emptySet(),
+                        otherPermission = setOf(key)
+                    ).getOrThrow()
+                } catch (_: CancellationException) {
+                    false
+                } catch (ex: Throwable) {
+                    throw ex
+                }
+        }
     }
 
     override suspend fun readData(
@@ -150,6 +195,16 @@ class HealthConnectManager(
         }
     }
 
+    private fun getReadHealthDataInBackgroundKey(): String {
+        return if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
+            SdkExtensions.getExtensionVersion(Build.VERSION_CODES.UPSIDE_DOWN_CAKE) >= 13
+        ) {
+            HealthPermissions.READ_HEALTH_DATA_IN_BACKGROUND
+        } else {
+            "android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND"
+        }
+    }
 }
 
 private val List<HealthDataType>.readPermissions: Set<String>

--- a/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/HealthConnectManager.kt
+++ b/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/HealthConnectManager.kt
@@ -58,31 +58,22 @@ class HealthConnectManager(
                     Result.success(isAuthorized)
                 }
             }
-            .mapCatching { isAuthorized ->
-                if (isAuthorized) return@mapCatching true
+            .flatMap { isAuthorized ->
+                if (isAuthorized) return@flatMap Result.success(true)
 
-                val otherPermission = if (requestReadHealthDataInBackground) {
-                    setOf(
-                        getReadHealthDataInBackgroundKey()
-                    )
-                } else {
-                    emptySet()
-                }
-                try {
-                    HealthConnectPermissionActivity.request(
-                        context,
-                        readPermissions = readTypes.readPermissions,
-                        writePermissions = writeTypes.writePermissions,
-                        otherPermission = otherPermission
-                    ).getOrThrow()
-                } catch (_: CancellationException) {
-                    false
-                } catch (ex: Throwable) {
-                    throw ex
-                }
+                requestPermissionWithActivity(
+                    readPermissions = readTypes.readPermissions,
+                    writePermissions = writeTypes.writePermissions,
+                    otherPermission = if (requestReadHealthDataInBackground) {
+                        setOf(getReadHealthDataInBackgroundKey())
+                    } else {
+                        emptySet()
+                    },
+                )
             }
 
-    override suspend fun isRevokeAuthorizationSupported(): Result<Boolean> = Result.success(true)
+    override suspend fun isRevokeAuthorizationSupported(): Result<Boolean> =
+        Result.success(true)
 
     override suspend fun revokeAuthorization(): Result<Unit> = runCatching {
         healthConnectClient.permissionController.revokeAllPermissions()
@@ -91,27 +82,20 @@ class HealthConnectManager(
     override suspend fun hasReadHealthDataInBackgroundPermission(): Result<Boolean> = runCatching {
         val grantedPermissions = healthConnectClient.permissionController.getGrantedPermissions()
         val key = getReadHealthDataInBackgroundKey()
-        grantedPermissions.contains(key)
+        key in grantedPermissions
     }
 
-    override suspend fun requestReadHealthDataInBackground(): Result<Boolean> {
+    override suspend fun requestReadHealthDataInBackgroundPermission(): Result<Boolean> {
         return hasReadHealthDataInBackgroundPermission()
-            .mapCatching { hasBackgroundPermission ->
-                if (hasBackgroundPermission) return@mapCatching true
-                try {
-                    val key = getReadHealthDataInBackgroundKey()
-                    HealthConnectPermissionActivity.request(
-                        context,
-                        readPermissions = emptySet(),
-                        writePermissions = emptySet(),
-                        otherPermission = setOf(key)
-                    ).getOrThrow()
-                } catch (_: CancellationException) {
-                    false
-                } catch (ex: Throwable) {
-                    throw ex
-                }
-        }
+            .flatMap { hasBackgroundPermission ->
+                if (hasBackgroundPermission) return Result.success(true)
+
+                requestPermissionWithActivity(
+                    readPermissions = emptySet(),
+                    writePermissions = emptySet(),
+                    otherPermission = setOf(getReadHealthDataInBackgroundKey()),
+                )
+            }
     }
 
     override suspend fun readData(
@@ -200,6 +184,25 @@ class HealthConnectManager(
         }
     }
 
+    private suspend fun requestPermissionWithActivity(
+        readPermissions: Set<String>,
+        writePermissions: Set<String>,
+        otherPermission: Set<String>,
+    ): Result<Boolean> {
+        return HealthConnectPermissionActivity.request(
+            context = context,
+            readPermissions = readPermissions,
+            writePermissions = writePermissions,
+            otherPermission = otherPermission,
+        ).recoverCatching { error ->
+            if (error is CancellationException) {
+                false
+            } else {
+                throw error
+            }
+        }
+    }
+
     private fun getReadHealthDataInBackgroundKey(): String {
         return if (
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
@@ -213,7 +216,7 @@ class HealthConnectManager(
 }
 
 private val List<HealthDataType>.readPermissions: Set<String>
-    get() = map { it.toHealthPermissions(isRead = true) }.flatten().toSet()
+    get() = flatMap { it.toHealthPermissions(isRead = true) }.toSet()
 
 private val List<HealthDataType>.writePermissions: Set<String>
-    get() = map { it.toHealthPermissions(isWrite = true) }.flatten().toSet()
+    get() = flatMap { it.toHealthPermissions(isWrite = true) }.toSet()

--- a/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/HealthConnectManagerFactory.kt
+++ b/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/HealthConnectManagerFactory.kt
@@ -3,6 +3,7 @@
 package com.viktormykhailiv.kmp.health
 
 import com.viktormykhailiv.kmp.health.legacy.GoogleFitManager
+import com.viktormykhailiv.kmp.health.legacy.NoHealthManager
 
 actual class HealthManagerFactory {
 
@@ -16,7 +17,7 @@ actual class HealthManagerFactory {
         }
     }
 
-    actual fun createManager(options: Options): HealthManager {
+    fun createManager(options: Options): HealthManager {
         val healthConnectManager = HealthConnectManager(ApplicationContextHolder.applicationContext)
 
         return if (healthConnectManager.isAvailable().getOrNull() == true) {
@@ -28,7 +29,7 @@ actual class HealthManagerFactory {
         }
     }
 
-    actual data class Options(
+    data class Options(
         val useGoogleFit: Boolean
     )
 }

--- a/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/HealthConnectManagerFactory.kt
+++ b/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/HealthConnectManagerFactory.kt
@@ -5,31 +5,55 @@ package com.viktormykhailiv.kmp.health
 import com.viktormykhailiv.kmp.health.legacy.GoogleFitManager
 import com.viktormykhailiv.kmp.health.legacy.NoHealthManager
 
+/**
+ * Factory class responsible for creating [HealthManager] instances.
+ *
+ * This implementation determines the most appropriate [HealthManager] based on device capabilities
+ * and the provided [HealthManagerFactoryOptions]. It prioritizes Health Connect, falling back
+ * to Google Fit if enabled in options, or a no-op implementation if neither is available.
+ */
 actual class HealthManagerFactory {
 
-    actual fun createManager(): HealthManager {
-        val healthConnectManager = HealthConnectManager(ApplicationContextHolder.applicationContext)
-
-        return if (healthConnectManager.isAvailable().getOrNull() == true) {
-            healthConnectManager
-        } else {
-            GoogleFitManager(ApplicationContextHolder.applicationContext)
-        }
-    }
-
-    fun createManager(options: Options): HealthManager {
-        val healthConnectManager = HealthConnectManager(ApplicationContextHolder.applicationContext)
-
-        return if (healthConnectManager.isAvailable().getOrNull() == true) {
-            healthConnectManager
-        } else if (options.useGoogleFit) {
-            GoogleFitManager(ApplicationContextHolder.applicationContext)
-        } else {
-            NoHealthManager()
-        }
-    }
-
-    data class Options(
-        val useGoogleFit: Boolean
+    @Deprecated(
+        "Use createManager with options",
+        replaceWith = ReplaceWith(
+            expression = "createManager(options = HealthManagerFactoryOptions.default())",
+            imports = arrayOf("com.viktormykhailiv.kmp.health.HealthManagerFactoryOptions"),
+        ),
     )
+    fun createManager(): HealthManager =
+        createManager(options = HealthManagerFactoryOptions.default())
+
+    actual fun createManager(options: HealthManagerFactoryOptions): HealthManager {
+        val healthConnectManager = HealthConnectManager(ApplicationContextHolder.applicationContext)
+
+        return when {
+            healthConnectManager.isAvailable().getOrNull() == true -> {
+                healthConnectManager
+            }
+
+            options.useGoogleFit -> {
+                GoogleFitManager(ApplicationContextHolder.applicationContext)
+            }
+
+            else -> {
+                NoHealthManager()
+            }
+        }
+    }
+
+}
+
+/**
+ * Configuration options for creating a [HealthManager] instance.
+ *
+ * @property useGoogleFit Whether to fallback to Google Fit if Health Connect is unavailable.
+ */
+actual data class HealthManagerFactoryOptions(
+    val useGoogleFit: Boolean,
+) {
+
+    actual companion object {
+        actual fun default() = HealthManagerFactoryOptions(useGoogleFit = true)
+    }
 }

--- a/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/HealthConnectManagerFactory.kt
+++ b/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/HealthConnectManagerFactory.kt
@@ -1,4 +1,4 @@
-@file:Suppress("DEPRECATION")
+@file:Suppress("DEPRECATION", "unused")
 
 package com.viktormykhailiv.kmp.health
 
@@ -16,4 +16,19 @@ actual class HealthManagerFactory {
         }
     }
 
+    actual fun createManager(options: Options): HealthManager {
+        val healthConnectManager = HealthConnectManager(ApplicationContextHolder.applicationContext)
+
+        return if (healthConnectManager.isAvailable().getOrNull() == true) {
+            healthConnectManager
+        } else if (options.useGoogleFit) {
+            GoogleFitManager(ApplicationContextHolder.applicationContext)
+        } else {
+            NoHealthManager()
+        }
+    }
+
+    actual data class Options(
+        val useGoogleFit: Boolean
+    )
 }

--- a/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/HealthConnectPermissionActivity.kt
+++ b/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/HealthConnectPermissionActivity.kt
@@ -23,11 +23,24 @@ internal class HealthConnectPermissionActivity : ComponentActivity() {
 
         private var continuation: CancellableContinuation<Result<Boolean>>? = null
 
+        /**
+         * Requests the specified Health Connect permissions by launching the [HealthConnectPermissionActivity].
+         *
+         * This is a suspending function that waits for the user to interact with the permission dialog
+         * and returns a [Result] indicating whether all requested permissions were granted.
+         *
+         * @param context The context used to start the activity.
+         * @param readPermissions A set of Health Connect read permission strings to request.
+         * @param writePermissions A set of Health Connect write permission strings to request.
+         * @param otherPermission A set of additional permission strings to request.
+         * @return A [Result] wrapping a [Boolean]. Returns `true` if all requested permissions
+         * were granted, `false` otherwise.
+         */
         suspend fun request(
             context: Context,
             readPermissions: Set<String>,
             writePermissions: Set<String>,
-            otherPermission: Set<String>
+            otherPermission: Set<String>,
         ): Result<Boolean> = suspendCancellableCoroutine {
             continuation?.cancel()
             continuation = it

--- a/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/HealthConnectPermissionActivity.kt
+++ b/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/HealthConnectPermissionActivity.kt
@@ -19,6 +19,7 @@ internal class HealthConnectPermissionActivity : ComponentActivity() {
     companion object {
         private const val KEY_READ_PERMISSIONS = "KEY_READ_PERMISSIONS"
         private const val KEY_WRITE_PERMISSIONS = "KEY_WRITE_PERMISSIONS"
+        private const val KEY_OTHER_PERMISSIONS = "KEY_OTHER_PERMISSIONS"
 
         private var continuation: CancellableContinuation<Result<Boolean>>? = null
 
@@ -26,6 +27,7 @@ internal class HealthConnectPermissionActivity : ComponentActivity() {
             context: Context,
             readPermissions: Set<String>,
             writePermissions: Set<String>,
+            otherPermission: Set<String>
         ): Result<Boolean> = suspendCancellableCoroutine {
             continuation?.cancel()
             continuation = it
@@ -34,6 +36,7 @@ internal class HealthConnectPermissionActivity : ComponentActivity() {
                 Intent(context, HealthConnectPermissionActivity::class.java)
                     .putExtra(KEY_READ_PERMISSIONS, readPermissions.toTypedArray())
                     .putExtra(KEY_WRITE_PERMISSIONS, writePermissions.toTypedArray())
+                    .putExtra(KEY_OTHER_PERMISSIONS, otherPermission.toTypedArray())
                     .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
             )
         }
@@ -45,7 +48,9 @@ internal class HealthConnectPermissionActivity : ComponentActivity() {
                 intent.getStringArrayExtra(KEY_READ_PERMISSIONS).orEmpty().toSet()
             val writePermissions =
                 intent.getStringArrayExtra(KEY_WRITE_PERMISSIONS).orEmpty().toSet()
-            return readPermissions + writePermissions
+            val otherPermission =
+                intent.getStringArrayExtra(KEY_OTHER_PERMISSIONS).orEmpty().toSet()
+            return readPermissions + writePermissions + otherPermission
         }
 
     private val contract = PermissionController.createRequestPermissionResultContract()

--- a/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/NoHealthManager.kt
+++ b/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/NoHealthManager.kt
@@ -1,0 +1,65 @@
+package com.viktormykhailiv.kmp.health
+
+import com.viktormykhailiv.kmp.health.region.RegionalPreferences
+import kotlin.time.Instant
+
+internal class NoHealthManager: HealthManager {
+
+    internal class HealthManagerUnavailableException: RuntimeException(
+        "Health manager is not available on this device"
+    )
+
+    private val unavailableException by lazy {
+        HealthManagerUnavailableException()
+    }
+
+    override fun isAvailable(): Result<Boolean> {
+        return Result.success(false)
+    }
+
+    override suspend fun isAuthorized(
+        readTypes: List<HealthDataType>,
+        writeTypes: List<HealthDataType>,
+    ): Result<Boolean> {
+        return Result.failure(unavailableException)
+    }
+
+    override suspend fun requestAuthorization(
+        readTypes: List<HealthDataType>,
+        writeTypes: List<HealthDataType>,
+    ): Result<Boolean> {
+        return Result.failure(unavailableException)
+    }
+
+    override suspend fun isRevokeAuthorizationSupported(): Result<Boolean> {
+        return Result.failure(unavailableException)
+    }
+
+    override suspend fun revokeAuthorization(): Result<Unit> {
+        return Result.failure(unavailableException)
+    }
+
+    override suspend fun readData(
+        startTime: Instant,
+        endTime: Instant,
+        type: HealthDataType,
+    ): Result<List<HealthRecord>> {
+        return Result.failure(unavailableException)
+    }
+
+    override suspend fun writeData(records: List<HealthRecord>): Result<Unit> {
+        return Result.failure(unavailableException)
+    }
+
+    override suspend fun aggregate(
+        startTime: Instant,
+        endTime: Instant,
+        type: HealthDataType,
+    ): Result<HealthAggregatedRecord> {
+        return Result.failure(unavailableException)
+    }
+
+    override suspend fun getRegionalPreferences(): Result<RegionalPreferences> {
+        return Result.failure(unavailableException)
+    }
+}

--- a/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/legacy/GoogleFitManager.kt
+++ b/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/legacy/GoogleFitManager.kt
@@ -58,7 +58,7 @@ class GoogleFitManager(
     override suspend fun requestAuthorization(
         readTypes: List<HealthDataType>,
         writeTypes: List<HealthDataType>,
-        requestReadHealthDataInBackground: Boolean
+        requestReadHealthDataInBackground: Boolean,
     ): Result<Boolean> =
         isAuthorized(readTypes = readTypes, writeTypes = writeTypes)
             .mapCatching { isAuthorized ->
@@ -87,13 +87,11 @@ class GoogleFitManager(
         GoogleSignIn.getClient(context, options).signOut().await()
     }
 
-    override suspend fun hasReadHealthDataInBackgroundPermission(): Result<Boolean> {
-        return Result.success(true)
-    }
+    override suspend fun hasReadHealthDataInBackgroundPermission(): Result<Boolean> =
+        Result.success(true)
 
-    override suspend fun requestReadHealthDataInBackground(): Result<Boolean> {
-        return Result.failure(NotImplementedError())
-    }
+    override suspend fun requestReadHealthDataInBackgroundPermission(): Result<Boolean> =
+        Result.failure(NotImplementedError())
 
     override suspend fun readData(
         startTime: Instant,

--- a/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/legacy/GoogleFitManager.kt
+++ b/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/legacy/GoogleFitManager.kt
@@ -58,6 +58,7 @@ class GoogleFitManager(
     override suspend fun requestAuthorization(
         readTypes: List<HealthDataType>,
         writeTypes: List<HealthDataType>,
+        requestReadHealthDataInBackground: Boolean
     ): Result<Boolean> =
         isAuthorized(readTypes = readTypes, writeTypes = writeTypes)
             .mapCatching { isAuthorized ->
@@ -84,6 +85,14 @@ class GoogleFitManager(
     override suspend fun revokeAuthorization(): Result<Unit> = runCatching {
         val options = GoogleSignInOptions.Builder(GoogleSignInOptions.DEFAULT_SIGN_IN).build()
         GoogleSignIn.getClient(context, options).signOut().await()
+    }
+
+    override suspend fun hasReadHealthDataInBackgroundPermission(): Result<Boolean> {
+        return Result.success(true)
+    }
+
+    override suspend fun requestReadHealthDataInBackground(): Result<Boolean> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun readData(

--- a/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/legacy/NoHealthManager.kt
+++ b/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/legacy/NoHealthManager.kt
@@ -1,5 +1,9 @@
-package com.viktormykhailiv.kmp.health
+package com.viktormykhailiv.kmp.health.legacy
 
+import com.viktormykhailiv.kmp.health.HealthAggregatedRecord
+import com.viktormykhailiv.kmp.health.HealthDataType
+import com.viktormykhailiv.kmp.health.HealthManager
+import com.viktormykhailiv.kmp.health.HealthRecord
 import com.viktormykhailiv.kmp.health.region.RegionalPreferences
 import kotlin.time.Instant
 

--- a/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/legacy/NoHealthManager.kt
+++ b/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/legacy/NoHealthManager.kt
@@ -7,15 +7,12 @@ import com.viktormykhailiv.kmp.health.HealthRecord
 import com.viktormykhailiv.kmp.health.region.RegionalPreferences
 import kotlin.time.Instant
 
-internal class NoHealthManager: HealthManager {
+internal class NoHealthManager : HealthManager {
 
-    internal class HealthManagerUnavailableException: RuntimeException(
-        "Health manager is not available on this device"
-    )
+    internal class HealthManagerUnavailableException :
+        RuntimeException("Health manager is not available on this device")
 
-    private val unavailableException by lazy {
-        HealthManagerUnavailableException()
-    }
+    private val unavailableException by lazy { HealthManagerUnavailableException() }
 
     override fun isAvailable(): Result<Boolean> {
         return Result.success(false)
@@ -31,7 +28,7 @@ internal class NoHealthManager: HealthManager {
     override suspend fun requestAuthorization(
         readTypes: List<HealthDataType>,
         writeTypes: List<HealthDataType>,
-        requestReadHealthDataInBackground: Boolean
+        requestReadHealthDataInBackground: Boolean,
     ): Result<Boolean> {
         return Result.failure(unavailableException)
     }
@@ -48,7 +45,7 @@ internal class NoHealthManager: HealthManager {
         return Result.failure(unavailableException)
     }
 
-    override suspend fun requestReadHealthDataInBackground(): Result<Boolean> {
+    override suspend fun requestReadHealthDataInBackgroundPermission(): Result<Boolean> {
         return Result.failure(unavailableException)
     }
 

--- a/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/legacy/NoHealthManager.kt
+++ b/health/src/androidMain/kotlin/com/viktormykhailiv/kmp/health/legacy/NoHealthManager.kt
@@ -31,6 +31,7 @@ internal class NoHealthManager: HealthManager {
     override suspend fun requestAuthorization(
         readTypes: List<HealthDataType>,
         writeTypes: List<HealthDataType>,
+        requestReadHealthDataInBackground: Boolean
     ): Result<Boolean> {
         return Result.failure(unavailableException)
     }
@@ -40,6 +41,14 @@ internal class NoHealthManager: HealthManager {
     }
 
     override suspend fun revokeAuthorization(): Result<Unit> {
+        return Result.failure(unavailableException)
+    }
+
+    override suspend fun hasReadHealthDataInBackgroundPermission(): Result<Boolean> {
+        return Result.failure(unavailableException)
+    }
+
+    override suspend fun requestReadHealthDataInBackground(): Result<Boolean> {
         return Result.failure(unavailableException)
     }
 

--- a/health/src/appleMain/kotlin/com/viktormykhailiv/kmp/health/HealthKitManager.kt
+++ b/health/src/appleMain/kotlin/com/viktormykhailiv/kmp/health/HealthKitManager.kt
@@ -72,6 +72,7 @@ internal class HealthKitManager : HealthManager {
     override suspend fun requestAuthorization(
         readTypes: List<HealthDataType>,
         writeTypes: List<HealthDataType>,
+        requestReadHealthDataInBackground: Boolean
     ): Result<Boolean> = suspendCancellableCoroutine { continuation ->
         healthStore.requestAuthorizationToShareTypes(
             typesToShare = writeTypes.map { it.toHKSampleType() }.flatten().filterNotNull().toSet(),
@@ -95,6 +96,14 @@ internal class HealthKitManager : HealthManager {
 
     override suspend fun revokeAuthorization(): Result<Unit> =
         Result.failure(NotImplementedError())
+
+    override suspend fun hasReadHealthDataInBackgroundPermission(): Result<Boolean> {
+        return Result.success(true)
+    }
+
+    override suspend fun requestReadHealthDataInBackground(): Result<Boolean> {
+        return Result.failure(NotImplementedError())
+    }
 
     @Suppress("UNCHECKED_CAST")
     override suspend fun readData(

--- a/health/src/appleMain/kotlin/com/viktormykhailiv/kmp/health/HealthKitManager.kt
+++ b/health/src/appleMain/kotlin/com/viktormykhailiv/kmp/health/HealthKitManager.kt
@@ -59,8 +59,8 @@ internal class HealthKitManager : HealthManager {
         writeTypes: List<HealthDataType>,
     ): Result<Boolean> = suspendCancellableCoroutine { continuation ->
         healthStore.getRequestStatusForAuthorizationToShareTypes(
-            typesToShare = writeTypes.map { it.toHKSampleType() }.flatten().filterNotNull().toSet(),
-            readTypes = readTypes.map { it.toHKSampleType() }.flatten().filterNotNull().toSet(),
+            typesToShare = writeTypes.flatMap { it.toHKSampleType() }.filterNotNull().toSet(),
+            readTypes = readTypes.flatMap { it.toHKSampleType() }.filterNotNull().toSet(),
         ) { status, error ->
             if (continuation.isCancelled) return@getRequestStatusForAuthorizationToShareTypes
 
@@ -75,11 +75,11 @@ internal class HealthKitManager : HealthManager {
     override suspend fun requestAuthorization(
         readTypes: List<HealthDataType>,
         writeTypes: List<HealthDataType>,
-        requestReadHealthDataInBackground: Boolean
+        requestReadHealthDataInBackground: Boolean,
     ): Result<Boolean> = suspendCancellableCoroutine { continuation ->
         healthStore.requestAuthorizationToShareTypes(
-            typesToShare = writeTypes.map { it.toHKSampleType() }.flatten().filterNotNull().toSet(),
-            readTypes = readTypes.map { it.toHKSampleType() }.flatten().filterNotNull().toSet(),
+            typesToShare = writeTypes.flatMap { it.toHKSampleType() }.filterNotNull().toSet(),
+            readTypes = readTypes.flatMap { it.toHKSampleType() }.filterNotNull().toSet(),
         ) { _, error ->
             if (continuation.isCancelled) return@requestAuthorizationToShareTypes
 
@@ -100,13 +100,11 @@ internal class HealthKitManager : HealthManager {
     override suspend fun revokeAuthorization(): Result<Unit> =
         Result.failure(NotImplementedError())
 
-    override suspend fun hasReadHealthDataInBackgroundPermission(): Result<Boolean> {
-        return Result.success(true)
-    }
+    override suspend fun hasReadHealthDataInBackgroundPermission(): Result<Boolean> =
+        Result.success(true)
 
-    override suspend fun requestReadHealthDataInBackground(): Result<Boolean> {
-        return Result.failure(NotImplementedError())
-    }
+    override suspend fun requestReadHealthDataInBackgroundPermission(): Result<Boolean> =
+        Result.failure(NotImplementedError())
 
     @Suppress("UNCHECKED_CAST")
     override suspend fun readData(
@@ -231,7 +229,7 @@ internal class HealthKitManager : HealthManager {
                     return@preferredUnitsForQuantityTypes
                 }
 
-                if (result == null || result.isEmpty()) {
+                if (result.isNullOrEmpty()) {
                     continuation.resumeWithException(IllegalStateException("Regional preferences data not found"))
                     return@preferredUnitsForQuantityTypes
                 }
@@ -275,7 +273,7 @@ internal class HealthKitManager : HealthManager {
             }
 
             when {
-                result == null || result.isEmpty() -> {
+                result.isNullOrEmpty() -> {
                     continuation.resume(Result.success(emptyList<Any>()))
                 }
 

--- a/health/src/appleMain/kotlin/com/viktormykhailiv/kmp/health/HealthKitManagerFactory.kt
+++ b/health/src/appleMain/kotlin/com/viktormykhailiv/kmp/health/HealthKitManagerFactory.kt
@@ -1,14 +1,7 @@
-@file:Suppress("unused")
-
 package com.viktormykhailiv.kmp.health
 
 actual class HealthManagerFactory {
 
     actual fun createManager(): HealthManager =
         HealthKitManager()
-
-    actual fun createManager(options: Options): HealthManager =
-        HealthKitManager()
-
-    actual object Options
 }

--- a/health/src/appleMain/kotlin/com/viktormykhailiv/kmp/health/HealthKitManagerFactory.kt
+++ b/health/src/appleMain/kotlin/com/viktormykhailiv/kmp/health/HealthKitManagerFactory.kt
@@ -1,7 +1,37 @@
 package com.viktormykhailiv.kmp.health
 
+/**
+ * iOS-specific implementation of [HealthManagerFactory] that provides access to [HealthKitManager].
+ *
+ * This factory is responsible for creating [HealthManager] instances using Apple's HealthKit framework.
+ * It utilizes [HealthManagerFactoryOptions] to configure the initialization process.
+ */
 actual class HealthManagerFactory {
 
-    actual fun createManager(): HealthManager =
+    @Deprecated(
+        "Use createManager with options",
+        replaceWith = ReplaceWith(
+            expression = "createManager(options = HealthManagerFactoryOptions.default())",
+            imports = arrayOf("com.viktormykhailiv.kmp.health.HealthManagerFactoryOptions"),
+        ),
+    )
+    fun createManager(): HealthManager =
+        createManager(options = HealthManagerFactoryOptions.default())
+
+    actual fun createManager(options: HealthManagerFactoryOptions): HealthManager =
         HealthKitManager()
+
+}
+
+/**
+ * Configuration options for creating a [HealthManager] instance via [HealthManagerFactory].
+ *
+ * These options provide a way to customize the initialization and behavior of the health manager.
+ * Use [default] to obtain a standard configuration instance.
+ */
+actual class HealthManagerFactoryOptions {
+
+    actual companion object {
+        actual fun default() = HealthManagerFactoryOptions()
+    }
 }

--- a/health/src/appleMain/kotlin/com/viktormykhailiv/kmp/health/HealthKitManagerFactory.kt
+++ b/health/src/appleMain/kotlin/com/viktormykhailiv/kmp/health/HealthKitManagerFactory.kt
@@ -1,7 +1,14 @@
+@file:Suppress("unused")
+
 package com.viktormykhailiv.kmp.health
 
 actual class HealthManagerFactory {
 
     actual fun createManager(): HealthManager =
         HealthKitManager()
+
+    actual fun createManager(options: Options): HealthManager =
+        HealthKitManager()
+
+    actual object Options
 }

--- a/health/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/HealthManager.kt
+++ b/health/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/HealthManager.kt
@@ -35,7 +35,8 @@ interface HealthManager {
      *
      * @param readTypes The list of [HealthDataType] to request read authorization for.
      * @param writeTypes The list of [HealthDataType] to request write authorization for.
-     * @return A [Result] containing true if authorization was granted, false otherwise.
+     * @param requestReadHealthDataInBackground Whether to also request permission to read health data while the app is in the background.
+     * @return A [Result] containing true if authorization was granted for the requested types, false otherwise.
      */
     suspend fun requestAuthorization(
         readTypes: List<HealthDataType>,
@@ -57,9 +58,22 @@ interface HealthManager {
      */
     suspend fun revokeAuthorization(): Result<Unit>
 
+    /**
+     * Checks if the app has permission to read health data while running in the background.
+     *
+     * @return A [Result] containing true if background read permission is granted, false otherwise.
+     */
     suspend fun hasReadHealthDataInBackgroundPermission(): Result<Boolean>
 
-    suspend fun requestReadHealthDataInBackground(): Result<Boolean>
+    /**
+     * Requests authorization from the user to read health data while the app is in the background.
+     *
+     * On some platforms (like Android with Health Connect), this may require a separate
+     * permission request from the standard authorization.
+     *
+     * @return A [Result] containing true if background read authorization was granted, false otherwise.
+     */
+    suspend fun requestReadHealthDataInBackgroundPermission(): Result<Boolean>
 
     /**
      * Reads health data records of the specified type within the given time range.

--- a/health/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/HealthManager.kt
+++ b/health/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/HealthManager.kt
@@ -15,11 +15,16 @@ interface HealthManager {
     suspend fun requestAuthorization(
         readTypes: List<HealthDataType>,
         writeTypes: List<HealthDataType>,
+        requestReadHealthDataInBackground: Boolean = false
     ): Result<Boolean>
 
     suspend fun isRevokeAuthorizationSupported(): Result<Boolean>
 
     suspend fun revokeAuthorization(): Result<Unit>
+
+    suspend fun hasReadHealthDataInBackgroundPermission(): Result<Boolean>
+
+    suspend fun requestReadHealthDataInBackground(): Result<Boolean>
 
     suspend fun readData(
         startTime: Instant,

--- a/health/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/HealthManagerFactory.kt
+++ b/health/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/HealthManagerFactory.kt
@@ -1,12 +1,5 @@
-@file:Suppress("unused")
-
 package com.viktormykhailiv.kmp.health
 
 expect class HealthManagerFactory() {
-
     fun createManager(): HealthManager
-
-    fun createManager(options: Options): HealthManager
-
-    class Options
 }

--- a/health/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/HealthManagerFactory.kt
+++ b/health/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/HealthManagerFactory.kt
@@ -1,6 +1,12 @@
+@file:Suppress("unused")
+
 package com.viktormykhailiv.kmp.health
 
 expect class HealthManagerFactory() {
 
     fun createManager(): HealthManager
+
+    fun createManager(options: Options): HealthManager
+
+    class Options
 }

--- a/health/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/HealthManagerFactory.kt
+++ b/health/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/HealthManagerFactory.kt
@@ -11,6 +11,25 @@ expect class HealthManagerFactory() {
      * Creates a new [HealthManager] instance for the current platform.
      *
      * @return A platform-specific implementation of [HealthManager].
+     *
+     * @see [HealthManagerFactoryOptions]
      */
-    fun createManager(): HealthManager
+    fun createManager(
+        options: HealthManagerFactoryOptions = HealthManagerFactoryOptions.default(),
+    ): HealthManager
+
+
+}
+
+/**
+ * Configuration options used by [HealthManagerFactory] to customize the creation of a [HealthManager].
+ *
+ * This is an [expect] class with platform-specific implementations, allowing for
+ * platform-specific configuration (e.g., specific data types or permissions).
+ */
+expect class HealthManagerFactoryOptions {
+
+    companion object {
+        fun default(): HealthManagerFactoryOptions
+    }
 }

--- a/sample/appleApps/appleApps.xcodeproj/project.pbxproj
+++ b/sample/appleApps/appleApps.xcodeproj/project.pbxproj
@@ -11,8 +11,6 @@
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
-		7741B0EC2DF49F010052CFA3 /* HealthKMP.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7741B0EB2DF49F010052CFA3 /* HealthKMP.xcframework */; };
-		7741B0ED2DF49F010052CFA3 /* HealthKMP.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7741B0EB2DF49F010052CFA3 /* HealthKMP.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		776420522DF48AD900D1DA3D /* watchosApp.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 776420482DF48AD800D1DA3D /* watchosApp.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
@@ -33,7 +31,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				7741B0ED2DF49F010052CFA3 /* HealthKMP.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -58,7 +55,6 @@
 		7555FF7B242A565900829871 /* HealthKMP.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HealthKMP.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		7741B0EB2DF49F010052CFA3 /* HealthKMP.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = HealthKMP.xcframework; path = ../../health/build/XCFrameworks/release/HealthKMP.xcframework; sourceTree = "<group>"; };
 		776420482DF48AD800D1DA3D /* watchosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = watchosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		778437312D5D188B00111377 /* iosApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = iosApp.entitlements; sourceTree = "<group>"; };
 		AB3632DC29227652001CCB65 /* Config.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
@@ -73,7 +69,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7741B0EC2DF49F010052CFA3 /* HealthKMP.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -98,7 +93,6 @@
 		42799AB246E5F90AF97AA0EF /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				7741B0EB2DF49F010052CFA3 /* HealthKMP.xcframework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -173,11 +167,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 776420562DF48AD900D1DA3D /* Build configuration list for PBXNativeTarget "watchosApp" */;
 			buildPhases = (
+				7741B0EF2DF49F550052CFA3 /* Compile Kotlin Framework */,
 				776420442DF48AD800D1DA3D /* Sources */,
 				776420452DF48AD800D1DA3D /* Frameworks */,
 				776420462DF48AD800D1DA3D /* Resources */,
 				7741B0EE2DF49F010052CFA3 /* Embed Frameworks */,
-				7741B0EF2DF49F550052CFA3 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -253,25 +247,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		7741B0EF2DF49F550052CFA3 /* ShellScript */ = {
+		7741B0EF2DF49F550052CFA3 /* Compile Kotlin Framework */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 8;
+			alwaysOutOfDate = 1;
+			buildActionMask = 12;
 			files = (
 			);
 			inputFileListPaths = (
 			);
 			inputPaths = (
 			);
+			name = "Compile Kotlin Framework";
 			outputFileListPaths = (
 			);
 			outputPaths = (
 			);
-			runOnlyForDeploymentPostprocessing = 1;
+			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :shared:packForXCode -PXCODE_CONFIGURATION=${CONFIGURATION}\n";
+			shellScript = "if [ \"YES\" = \"$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED\" ]; then\n  echo \"Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \\\"YES\\\"\"\n  exit 0\nfi\ncd \"$SRCROOT/..\"\n.././gradlew :health:embedAndSignAppleFrameworkForXcode\n";
 		};
 		F36B1CEB2AD83DDC00CB74D5 /* Compile Kotlin Framework */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -508,8 +505,10 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "${TEAM_ID}";
 				ENABLE_PREVIEWS = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				"FRAMEWORK_SEARCH_PATHS[arch=*]" = "$(SRCROOT)/../shared/build/XCFrameworks/debug/shared.xcframework\n";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = HealthKMP;
@@ -549,8 +548,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "${TEAM_ID}";
 				ENABLE_PREVIEWS = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
-				"FRAMEWORK_SEARCH_PATHS[arch=*]" = "$(SRCROOT)/../shared/build/XCFrameworks/release/shared.xcframework";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = HealthKMP;

--- a/sample/composeApp/src/androidMain/AndroidManifest.xml
+++ b/sample/composeApp/src/androidMain/AndroidManifest.xml
@@ -32,5 +32,6 @@
     <uses-permission android:name="android.permission.health.WRITE_STEPS" />
     <uses-permission android:name="android.permission.health.READ_WEIGHT" />
     <uses-permission android:name="android.permission.health.WRITE_WEIGHT" />
+    <uses-permission android:name="android.permission.health.READ_HEALTH_DATA_IN_BACKGROUND" />
 
 </manifest>

--- a/sample/composeApp/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/sample/SampleApp.kt
+++ b/sample/composeApp/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/sample/SampleApp.kt
@@ -120,8 +120,8 @@ fun SampleApp() {
 
     var isAvailableResult by remember { mutableStateOf(Result.success(false)) }
     var isAuthorizedResult by remember { mutableStateOf<Result<Boolean>?>(null) }
-    var hasBackgroundReadPermissionResult by remember { mutableStateOf<Result<Boolean>?>(null) }
     var isRevokeSupported by remember { mutableStateOf(false) }
+    var hasBackgroundReadPermissionResult by remember { mutableStateOf<Result<Boolean>?>(null) }
     var regionalPreferencesResult by remember { mutableStateOf<Result<RegionalPreferences>?>(null) }
 
     LaunchedEffect(health) {
@@ -133,8 +133,8 @@ fun SampleApp() {
             writeTypes = writeTypes,
         )
         isRevokeSupported = health.isRevokeAuthorizationSupported().getOrNull() == true
-        regionalPreferencesResult = health.getRegionalPreferences()
         hasBackgroundReadPermissionResult = health.hasReadHealthDataInBackgroundPermission()
+        regionalPreferencesResult = health.getRegionalPreferences()
     }
 
     val navController = rememberNavController()
@@ -182,9 +182,10 @@ fun SampleApp() {
                                         coroutineScope.launch {
                                             isAuthorizedResult = health.requestAuthorization(
                                                 readTypes = readTypes,
-                                                writeTypes = writeTypes
+                                                writeTypes = writeTypes,
                                             )
-                                            hasBackgroundReadPermissionResult = health.hasReadHealthDataInBackgroundPermission()
+                                            hasBackgroundReadPermissionResult =
+                                                health.hasReadHealthDataInBackgroundPermission()
                                         }
                                     },
                                 )
@@ -198,7 +199,8 @@ fun SampleApp() {
                                                 readTypes = readTypes,
                                                 writeTypes = writeTypes,
                                             )
-                                            hasBackgroundReadPermissionResult = health.hasReadHealthDataInBackgroundPermission()
+                                            hasBackgroundReadPermissionResult =
+                                                health.hasReadHealthDataInBackgroundPermission()
                                         }
                                     },
                                     colors = ButtonDefaults.buttonColors(
@@ -209,7 +211,12 @@ fun SampleApp() {
                                     Text("Revoke authorization")
                                 }
 
-                            if (isAvailableResult.getOrNull() == true &&
+                            hasBackgroundReadPermissionResult
+                                ?.onSuccess {
+                                    Text("Has background read permission")
+                                }
+                            if (
+                                isAvailableResult.getOrNull() == true &&
                                 isAuthorizedResult?.getOrNull() == true &&
                                 hasBackgroundReadPermissionResult?.getOrNull() != true
                             ) {
@@ -217,7 +224,8 @@ fun SampleApp() {
                                     text = "Request background read permission",
                                     onClick = {
                                         coroutineScope.launch {
-                                            hasBackgroundReadPermissionResult = health.requestReadHealthDataInBackground()
+                                            hasBackgroundReadPermissionResult =
+                                                health.requestReadHealthDataInBackgroundPermission()
                                         }
                                     },
                                 )

--- a/sample/composeApp/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/sample/SampleApp.kt
+++ b/sample/composeApp/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/sample/SampleApp.kt
@@ -120,6 +120,7 @@ fun SampleApp() {
 
     var isAvailableResult by remember { mutableStateOf(Result.success(false)) }
     var isAuthorizedResult by remember { mutableStateOf<Result<Boolean>?>(null) }
+    var hasBackgroundReadPermissionResult by remember { mutableStateOf<Result<Boolean>?>(null) }
     var isRevokeSupported by remember { mutableStateOf(false) }
     var regionalPreferencesResult by remember { mutableStateOf<Result<RegionalPreferences>?>(null) }
 
@@ -133,6 +134,7 @@ fun SampleApp() {
         )
         isRevokeSupported = health.isRevokeAuthorizationSupported().getOrNull() == true
         regionalPreferencesResult = health.getRegionalPreferences()
+        hasBackgroundReadPermissionResult = health.hasReadHealthDataInBackgroundPermission()
     }
 
     val navController = rememberNavController()
@@ -182,6 +184,7 @@ fun SampleApp() {
                                                 readTypes = readTypes,
                                                 writeTypes = writeTypes,
                                             )
+                                            hasBackgroundReadPermissionResult = health.hasReadHealthDataInBackgroundPermission()
                                         }
                                     },
                                 )
@@ -195,6 +198,7 @@ fun SampleApp() {
                                                 readTypes = readTypes,
                                                 writeTypes = writeTypes,
                                             )
+                                            hasBackgroundReadPermissionResult = health.hasReadHealthDataInBackgroundPermission()
                                         }
                                     },
                                     colors = ButtonDefaults.buttonColors(
@@ -204,6 +208,20 @@ fun SampleApp() {
                                 ) {
                                     Text("Revoke authorization")
                                 }
+
+                            if (isAvailableResult.getOrNull() == true &&
+                                isAuthorizedResult?.getOrNull() == true &&
+                                hasBackgroundReadPermissionResult?.getOrNull() != true
+                            ) {
+                                AppButton(
+                                    text = "Request background read permission",
+                                    onClick = {
+                                        coroutineScope.launch {
+                                            hasBackgroundReadPermissionResult = health.requestReadHealthDataInBackground()
+                                        }
+                                    },
+                                )
+                            }
 
                             regionalPreferencesResult
                                 ?.onSuccess {

--- a/sample/composeApp/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/sample/SampleApp.kt
+++ b/sample/composeApp/src/commonMain/kotlin/com/viktormykhailiv/kmp/health/sample/SampleApp.kt
@@ -182,7 +182,7 @@ fun SampleApp() {
                                         coroutineScope.launch {
                                             isAuthorizedResult = health.requestAuthorization(
                                                 readTypes = readTypes,
-                                                writeTypes = writeTypes,
+                                                writeTypes = writeTypes
                                             )
                                             hasBackgroundReadPermissionResult = health.hasReadHealthDataInBackgroundPermission()
                                         }


### PR DESCRIPTION
# Add background synchronization support, ignore Google Fit, fix iOS build

## 📝 Description
This Pull Request introduces key improvements to data synchronization and fixes the build process for iOS and watchOS.

## 🎯 Motivation
The goal is to increase application flexibility on the Android platform and ensure build stability for the Apple ecosystem. We want to allow clients to utilize modern Health Connect features without being tethered to Google Fit.

### 🤖 Android & Health Connect
* **Decoupling Google Fit:** Modified the logic to ensure the app no longer forces the use of Google Fit. Our primary focus is now **Google Health Connect**. The decision of which Android service to utilize is now left to the client.
* **Background Sync:** Added support for background data reading, specifically implementing the flow for requesting and obtaining the necessary background permissions.

### 🍎 iOS & watchOS
* **Build Fixes:** Resolved critical issues in the iOS build pipeline that were preventing successful compilation.
* **WatchOS Support:** Fixed specific build errors related to the watchOS targets.

---

> [!NOTE]  
> If necessary, I can split these changes into smaller, separate Pull Requests upon request.